### PR TITLE
Update to the correct version of the plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath group: 'org.intermine', name: 'plugin', version: '1.+'
+        classpath group: 'org.intermine', name: 'plugin', version: System.getProperty("imVersion")
     }
 }
 


### PR DESCRIPTION
It says to use the plugin v1.0. Do you know why? Must be a copy / paste error.

Anyway, we should update to the latest version.